### PR TITLE
Minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The library uses a model of [immutable layout and tile definitions](http://moniq
 
 ### Fetch data formatted for rendering a tile
 
-Data of a dashboard tile, preformatted for rendering, [can be fetched easily](http://monique-dashboards.readthedocs.io/en/latest/tutorial.html#tutorial-tile-data). The library manages data series' names and colors, and enables [customizing tiles](http://monique-dashboards.readthedocs.io/en/latest/tilewidgets.html#formatting-tile-data-tilewidgets-and-drawers). Monique Dashboards don't depend on any frontend libary.
+Data of a dashboard tile, preformatted for rendering, [can be fetched easily](http://monique-dashboards.readthedocs.io/en/latest/tutorial.html#tutorial-tile-data). The library manages data series' names and colors, and enables [customizing tiles](http://monique-dashboards.readthedocs.io/en/latest/tilewidgets.html#formatting-tile-data-tilewidgets-and-drawers). Monique Dashboards don't depend on any frontend library.
 
 ### Manage data series directly
 

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -31,7 +31,7 @@ Sample code for applying the :func:`~mqe.layouts.place_tile` operation to a spec
 
     > New tile placed with visual_options {'width': 4, 'height': 4, 'x': 4, 'y': 0}
 
-The sample also shows a usage of the |lmr| object - a result of modifiying a layout returned by many functions. The object lists new, detached and replaced tiles.
+The sample also shows a usage of the |lmr| object - a result of modifying a layout returned by many functions. The object lists new, detached and replaced tiles.
 
 Detaching a tile from a layout is done in a similar way to placing, by calling :func:`.detach_tile`.
 

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -4,7 +4,7 @@ Other library features
 Configuration module
 --------------------
 
-The configuration module `mqeconfig.py <https://github.com/monique-dashboards/monique/mqe/mqeconfig.py>`_ specifies various options, including connection parameters to a database. The options can be overriden by putting the ``mqeconfig_override.py`` file in the ``$PYTHONPATH``. The config variables defined in the file will overwrite the default values present in ``mqeconfig.py``. The ``mqeconfig.py`` file could be also copied in whole into the ``mqeconfig_override.py`` file to enable editing all options.
+The configuration module `mqeconfig.py <https://github.com/monique-dashboards/monique/mqe/mqeconfig.py>`_ specifies various options, including connection parameters to a database. The options can be overridden by putting the ``mqeconfig_override.py`` file in the ``$PYTHONPATH``. The config variables defined in the file will overwrite the default values present in ``mqeconfig.py``. The ``mqeconfig.py`` file could be also copied in whole into the ``mqeconfig_override.py`` file to enable editing all options.
 
 An alternative way is to set the needed options in code, before using the library's code::
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -178,9 +178,9 @@ Sample :data:`tile_config`::
 
        An optional subset of :data:`tile_options` parameters that should be put into the final :data:`tile_options`.
 
-       For security reasons the follwing keys contained in the subset are ignored:
+       For security reasons the following keys contained in the subset are ignored:
 
-       * :data:`~tile_options.owner_id` and :data:`~tile_options.report_id` - the parameters must be explictly passed to the :meth:`~mqe.tiles.Tile.insert` or the :meth:`~mqe.tiles.Tile.insert_similar` method
+       * :data:`~tile_options.owner_id` and :data:`~tile_options.report_id` - the parameters must be explicitly passed to the :meth:`~mqe.tiles.Tile.insert` or the :meth:`~mqe.tiles.Tile.insert_similar` method
 
        * :data:`~tile_options.series_configs` - the attribute is compiled from :attr:`tile_config.series_spec_list`
 

--- a/docs/tilewidgets.rst
+++ b/docs/tilewidgets.rst
@@ -133,7 +133,7 @@ The second are colors coming from **default options** - options previously assig
 
 The third are default colors defined in the config module as :attr:`mqe.mqeconfig.DEFAULT_COLORS`.
 
-The first and the third source doesn't require further explanation, but how default options work? After a tile is created, we can tell that we want its :data:`tile_options` to be included in a pool of default options available for other tiles by calling :func:`.update_default_options`. After doing it and creating another tile that uses the same |SeriesSpec|, the assigned series' color will come from the default options (unless it's overriden by :data:`tile_options.colors`). The sample code shows the behaviour::
+The first and the third source doesn't require further explanation, but how default options work? After a tile is created, we can tell that we want its :data:`tile_options` to be included in a pool of default options available for other tiles by calling :func:`.update_default_options`. After doing it and creating another tile that uses the same |SeriesSpec|, the assigned series' color will come from the default options (unless it's overridden by :data:`tile_options.colors`). The sample code shows the behaviour::
 
     from mqe.dataseries import update_default_options
 

--- a/mqe/dao/cassandradb/cassandradao.py
+++ b/mqe/dao/cassandradb/cassandradao.py
@@ -168,10 +168,10 @@ class CassReportDAO(ReportDAO):
                                    IF NOT EXISTS""",
                                   [owner_id, report_name, report_id])
         lwt_res = execute_lwt(insert_report_name)
-        if lwt_res == False:
+        if not lwt_res:
             log.info('Race condition in creating a new report %r', report_name)
             return None
-        elif lwt_res == None:
+        elif lwt_res is None:
             rows = c.cass.execute("""SELECT report_id FROM mqe.report_by_owner_id_report_name
                                    WHERE owner_id=? AND report_name=? /* SERIAL */""",
                                   [owner_id, report_name],
@@ -399,10 +399,9 @@ class CassReportInstanceDAO(ReportInstanceDAO):
         
         diskspace = self._compute_ri_diskspace(ri)
 
-        qs = []
-        qs.append(bind("""DELETE FROM mqe.report_instance_metadata
-                          WHERE report_id=? AND day=? AND report_instance_id=?""",
-                       [report_id, ri['day'], report_instance_id]))
+        qs = [bind("""DELETE FROM mqe.report_instance_metadata
+                      WHERE report_id=? AND day=? AND report_instance_id=?""",
+                   [report_id, ri['day'], report_instance_id])]
         for tags_subset in util.powerset(ri['all_tags']):
             tags_repr = tags_repr_from_tags(tags_subset)
             qs.append(bind("""DELETE FROM mqe.report_instance WHERE report_id=? AND day=? AND tags_repr=? AND report_instance_id=?""", [report_id, ri['day'], tags_repr, report_instance_id]))
@@ -697,10 +696,10 @@ class CassLayoutDAO(LayoutDAO):
             return update_rows
 
         lwt_res = execute_lwt(do_set_layout)
-        if lwt_res == False:
+        if not lwt_res:
             log.info('Setting new layout failed on LWT transaction')
             return False
-        if lwt_res == None:
+        if lwt_res is None:
             log.info('Setting new layout resulted in unknown LWT result')
             saved_layout_id = c.cass.execute_fst(
                     """SELECT {layout_id_colname} FROM mqe.dashboard_layout_def

--- a/mqe/dao/cassandradb/cassandrautil.py
+++ b/mqe/dao/cassandradb/cassandrautil.py
@@ -109,7 +109,7 @@ def is_transaction_applied(update_rows):
     return update_rows[0].get('[applied]')
 
 def execute_lwt(fun):
-    """Execute the function ``fun`` that makes a Cassandra lightweight transaction and returns the result rows and tell whether the transaction was successful. The :func:`execute_lwt` function handles the case when Cassandra doesn't know if the transation was applied.
+    """Execute the function ``fun`` that makes a Cassandra lightweight transaction and returns the result rows and tell whether the transaction was successful. The :func:`execute_lwt` function handles the case when Cassandra doesn't know if the transaction was applied.
 
     :return: ``True`` if applied, ``False`` if not applied, ``None`` if it's unknown if applied."""
     try:
@@ -150,7 +150,7 @@ class Cassandra(object):
 
     @cached_property
     def session(self):
-        "The :class:`cassandra.cluster.Session` object created from the :attr:`cluster` that allows executing queries. The :attr:`session` returns rows as dictionaries (instead of the default namedtuples)."
+        """The :class:`cassandra.cluster.Session` object created from the :attr:`cluster` that allows executing queries. The :attr:`session` returns rows as dictionaries (instead of the default namedtuples)."""
         try:
             csession = self.cluster.connect()
         except Exception as e:

--- a/mqe/dashboards.py
+++ b/mqe/dashboards.py
@@ -65,7 +65,7 @@ class Dashboard(Row):
                  len(tile_by_id), self.dashboard_id, self.dashboard_name)
 
     def key(self):
-        return (self.owner_id, self.dashboard_id)
+        return self.owner_id, self.dashboard_id
 
 
 

--- a/mqe/dataseries.py
+++ b/mqe/dataseries.py
@@ -351,8 +351,8 @@ def guess_series_spec(report, report_instance, sample_rowno, sample_colno):
             return 0
         label_string_keys = [ev.to_string_key() for ev in label_vals]
 
-        row_occurences = label_string_keys.count(row[colno].to_string_key())
-        if row_occurences != 1:
+        row_occurrences = label_string_keys.count(row[colno].to_string_key())
+        if row_occurrences != 1:
             return 0
 
         uniq_vals = util.uniq_sameorder(label_string_keys)
@@ -477,7 +477,7 @@ class SeriesDef(Row):
         self['to_rid'] = to_rid
 
     def key(self):
-        return (self['report_id'], self.tags, self['series_spec'])
+        return self['report_id'], self.tags, self['series_spec']
 
 
 

--- a/mqe/ext/csv.py
+++ b/mqe/ext/csv.py
@@ -108,7 +108,7 @@ class DictReader:
         # unlike the basic reader, we prefer not to return blanks,
         # because we will typically wind up with a dict full of None
         # values
-        while row == []:
+        while not row:
             row = self.reader.next()
         d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
@@ -161,10 +161,10 @@ except NameError:
     complex = float
 
 class Sniffer:
-    '''
+    """
     "Sniffs" the format of a CSV file (i.e. delimiter, quotechar)
     Returns a Dialect object.
-    '''
+    """
     def __init__(self):
         # in case there is more than one possible delimiter
         self.preferred = [',', '\t', ';', ' ', ':']
@@ -223,7 +223,7 @@ class Sniffer:
 
         if not matches:
             # (quotechar, doublequote, delimiter, skipinitialspace)
-            return ('', False, None, 0)
+            return '', False, None, 0
         quotes = {}
         delims = {}
         spaces = 0
@@ -272,7 +272,7 @@ class Sniffer:
         else:
             doublequote = False
 
-        return (quotechar, doublequote, delim, skipinitialspace)
+        return quotechar, doublequote, delim, skipinitialspace
 
 
     _ascii = {chr(c) for c in range(127) if not chr(c).isalnum()} # 7-bit ASCII
@@ -349,14 +349,14 @@ class Sniffer:
                 delim = delims.keys()[0]
                 skipinitialspace = (data[0].count(delim) ==
                                     data[0].count("%c " % delim))
-                return (delim, skipinitialspace)
+                return delim, skipinitialspace
 
             # analyze another chunkLength lines
             start = end
             end += chunkLength
 
         if not delims:
-            return ('', 0)
+            return '', 0
 
         # if there's more than one, fall back to a 'preferred' list
         if len(delims) > 1:
@@ -364,7 +364,7 @@ class Sniffer:
                 if d in delims.keys():
                     skipinitialspace = (data[0].count(d) ==
                                         data[0].count("%c " % d))
-                    return (d, skipinitialspace)
+                    return d, skipinitialspace
 
         # nothing else indicates a preference, pick the character that
         # dominates(?)
@@ -374,7 +374,7 @@ class Sniffer:
 
         skipinitialspace = (data[0].count(delim) ==
                             data[0].count("%c " % delim))
-        return (delim, skipinitialspace)
+        return delim, skipinitialspace
 
 
     def has_header(self, sample, _sniff_result=None):

--- a/mqe/ext/test_csv.py
+++ b/mqe/ext/test_csv.py
@@ -139,7 +139,8 @@ class Test_Csv(unittest.TestCase):
         # Check that exceptions are passed up the chain
         class BadList:
             def __len__(self):
-                return 10;
+                return 10
+
             def __getitem__(self, i):
                 if i > 2:
                     raise IOError
@@ -307,7 +308,7 @@ class Test_Csv(unittest.TestCase):
             self.assertRaises(StopIteration, r.next)
             self.assertEqual(r.line_num, 3)
 
-    def test_roundtrip_quoteed_newlines(self):
+    def test_roundtrip_quoted_newlines(self):
         fd, name = tempfile.mkstemp()
         fileobj = os.fdopen(fd, "w+b")
         try:

--- a/mqe/layouts.py
+++ b/mqe/layouts.py
@@ -168,10 +168,8 @@ class Layout(object):
     def props_of_tile(self, tile):
         from mqe import tpcreator
 
-        props = {}
-
-        props['report_id'] = tile.tile_options['report_id']
-        props['tags'] = tile.tile_options['tags']
+        props = {'report_id': tile.tile_options['report_id'],
+                 'tags': tile.tile_options['tags']}
 
         if tile.has_sscs():
             props['sscs'] = 1
@@ -454,7 +452,7 @@ def apply_mods(mods, owner_id, dashboard_id, for_layout_id,
     layout with ID ``for_layout_id``
 
     :return: a :class:`LayoutModificationResult` describing
-        the modifications if the operation was successfull, ``None`` otherwise"""
+        the modifications if the operation was successful, ``None`` otherwise"""
     layout_mod = LayoutModification(mods)
     return layout_mod.apply(owner_id, dashboard_id, for_layout_id, max_tries)
 
@@ -669,7 +667,7 @@ def repack_mod():
                 if num is not None:
                     num_key = num
                     break
-        return (num_key, ','.join(tags))
+        return num_key, ','.join(tags)
 
     def do_repack(layout_mod):
         layout_dict_items = _sort_layout_items(layout_mod.layout.layout_dict, 'y')
@@ -681,11 +679,11 @@ def repack_mod():
             props = layout_mod.layout.get_tile_props(tile_id)
             master_id = props.get('master_id') if props else None
             if not master_id:
-                return (tile_id_to_index[tile_id], DEFAULT_RICH_KEY)
+                return tile_id_to_index[tile_id], DEFAULT_RICH_KEY
             if master_id not in tile_id_to_index:
                 #log.warn('No group leader in layout_dict')
-                return (tile_id_to_index[tile_id], DEFAULT_RICH_KEY)
-            return (tile_id_to_index[master_id], _tags_to_rich_key(props.get('tags', [])))
+                return tile_id_to_index[tile_id], DEFAULT_RICH_KEY
+            return tile_id_to_index[master_id], _tags_to_rich_key(props.get('tags', []))
 
         layout_dict_items.sort(key=key)
 

--- a/mqe/mqeconfig.py
+++ b/mqe/mqeconfig.py
@@ -1,5 +1,5 @@
 ### The configuration of the Monique Dashboards library. The configuration can be
-### overriden by putting a subset of config variables in mqeconfig_override.py file
+### overridden by putting a subset of config variables in mqeconfig_override.py file
 ### (which must be in PYTHONPATH).
 
 

--- a/mqe/pars/asciiparsing.py
+++ b/mqe/pars/asciiparsing.py
@@ -172,7 +172,7 @@ class AsciiSurface(parsing.InputParser):
                 common = 0
             common_ratio = common / (token.end-token.start)
             distance = abs( ((token.start + token.end) / 2) - ((spec.col_end + spec.col_start) / 2) )
-            return (common_ratio, -distance)
+            return common_ratio, -distance
         for lineno, line_tokens in enumerate(self.tokens_by_lineno):
             if lineno in self.skipped_linenos:
                 continue

--- a/mqe/pars/basicparsing.py
+++ b/mqe/pars/basicparsing.py
@@ -297,8 +297,8 @@ class JsonDeepParser(JsonParser):
                         raise parsing.NotParsable('Too many expanded')
 
                 if len(to_rewrite) == 1 and to_rewrite[0] is xdoc:
-                    return (xdoc, False)
-                return (to_rewrite, True)
+                    return xdoc, False
+                return to_rewrite, True
 
             if isinstance(xdoc, list):
                 res = []
@@ -308,9 +308,9 @@ class JsonDeepParser(JsonParser):
                         res.extend(rdoc)
                     else:
                         res.append(rdoc)
-                return (res, False)
+                return res, False
 
-            return (xdoc, False)
+            return xdoc, False
 
         def to_items(key, value):
             if not isinstance(value, dict) or (not value and key):

--- a/mqe/reports.py
+++ b/mqe/reports.py
@@ -92,7 +92,7 @@ class ReportInstance(Row):
     skip_printing = ('ri_data', 'input_string', 'day', 'tags')
 
     def key(self):
-        return (self.report_instance_id, tuple(self.all_tags))
+        return self.report_instance_id, tuple(self.all_tags)
 
 
 

--- a/mqe/tiles.py
+++ b/mqe/tiles.py
@@ -260,7 +260,7 @@ class Tile(Row):
     def key(self):
         if self.tile_id is None:
             raise ValueError('Cannot compute hash/cmp key for non-inserted tile')
-        return (self.dashboard_id, self.tile_id)
+        return self.dashboard_id, self.tile_id
 
 
 

--- a/mqe/tilewidgets.py
+++ b/mqe/tilewidgets.py
@@ -128,11 +128,9 @@ class Tilewidget(object):
 
     def get_tile_data(self, limit=None):
         """Called by :meth:`~mqe.tiles.Tile.get_tile_data`"""
-        data = {}
+        data = {'report_name': self.tile.report.report_name,
+                'latest_extra_ri_data': {}}
 
-        data['report_name'] = self.tile.report.report_name
-
-        data['latest_extra_ri_data'] = {}
         latest_rid = self.tile.report.fetch_latest_instance_id(self.tile_options['tags'])
         if latest_rid is not None:
             latest_extra_ri_data = c.dao.ReportInstanceDAO.select_extra_ri_data(self.tile.report_id,
@@ -166,9 +164,7 @@ class Tilewidget(object):
 
     def get_new_tile_data(self, after_report_instance_id):
         """Called by :meth:`~mqe.tiles.Tile.get_new_tile_data`"""
-        data = {}
-
-        data['series_data'] = []
+        data = {'series_data': []}
 
         self.fill_new_tile_data(data, after_report_instance_id)
 

--- a/mqe/tpcreator.py
+++ b/mqe/tpcreator.py
@@ -40,8 +40,7 @@ def suggested_tpcreator_prefixes(tag):
     """Returns a list of suggested tag prefixes that can be included in a
     :data:`tpcreator_uispec`: an empty string, the part until the ``:`` character
     and the full tag value."""
-    res = []
-    res.append('')
+    res = ['']
     if TPCREATOR_SEPARATOR in tag:
         res.append(_tpcreator_prefix(tag))
     res.append(tag)

--- a/mqe/util.py
+++ b/mqe/util.py
@@ -359,7 +359,7 @@ def partition_numstr(s):
             break
     else:
         k = len(s)
-    return (get_float(s[:k].replace(',', '.')), s[k:])
+    return get_float(s[:k].replace(',', '.')), s[k:]
 
 _re_find_number = re.compile(r'[-+]?\d+[\.]?\d*')
 def find_number(s):


### PR DESCRIPTION
### Summary:

* Simplify boolean expressions
* Use `is` and `is not` for comparisons with None
* Create dicts using dict literals
* Create lists usings list literals
* Use `self` as methods first parameter
* Remove redundant parentheses
* Use triple-quoted docstrings
* Remove trailing semicolon
* Remove unnecessary backslashes
* Fix typos
    * `quoteed` -> `quoted`
    * `overriden` -> `overridden`
    * `modifiying` -> `modifying`
    * `follwing` -> `following`
    * `explictly` -> `explicitly`
    * `transation` -> `transaction`
    * `occurences` -> `occurrences`
    * `successfull` -> `successful`
    * `libary` -> `library`